### PR TITLE
Correct FOD_SENSOR_Y value

### DIFF
--- a/fod/FingerprintInscreen.cpp
+++ b/fod/FingerprintInscreen.cpp
@@ -37,7 +37,7 @@
 #define FOD_STATUS_OFF 0
 
 #define FOD_SENSOR_X 293
-#define FOD_SENSOR_Y 1356
+#define FOD_SENSOR_Y 1383
 #define FOD_SENSOR_SIZE 134
 
 #define BRIGHTNESS_PATH "/sys/class/backlight/panel0-backlight/brightness"


### PR DESCRIPTION
For some reason, the FOD spot on stock ROM is a bit lower (about 27px)

Screenshot on stock ROM: https://imgur.com/aZsfhlR
Screenshot on Syberia ROM: https://imgur.com/4jTm5pH